### PR TITLE
Create com.xserve-frontpanel.daemon.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,34 @@ cmake . && make
 ```bash
 ./hwmond
 ```
+
+---
+## Auto loading with Launchd
+The following optional instructions will walk you through using the included plist to auto load the hwmond file at boot and keep it running while the machine is running.
+
+Start by editing com.xserve-frontpanel.daemon.plist 
+
+```<string>/xserve-frontpanel/hwmond</string>
+```
+
+portion of the com.xserve-frontpanel.daemon.plist to have the location of where you have installed the file, IE. 
+
+```<string>/PATH-TO-HWMOND/hwmond</string>
+```
+
+One you have set the path to the hwmond. Open the terminal and cd to the containing directory. Once in the directory set the  permissions for the com.xserve-frontpanel.daemon.plist to 644 using the following command.
+
+```chmod 644 com.xserve-frontpanel.daemon.plist
+```
+
+Rather than physcially placing the plist into the LaunchDaemons directory it is better to create a symlink as follows, however if you prefer you can physically copy the file to the LaunchDaemons directory.
+
+```sudo ln -s com.xserve-frontpanel.daemon.plist /Library/LaunchDaemons/com.xserve-frontpanel.daemon.plist
+```
+
+You now need to load the plist into Launchd ( the process that loads and keeps stuff running )
+
+```sudo launchctl load -w /Library/LaunchDaemons/com.xserve-frontpanel.daemon.plist
+```
+
+The “-w” part of the last command tells the computer this process has to ALWAYS run. So even if you kill the HWmond process Launchd will start it back up. This ensure the front panel lights stay functional as long as the system is running.

--- a/com.xserve-frontpanel.daemon.plist
+++ b/com.xserve-frontpanel.daemon.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.xserve-frontpanel.daemon.plist</string>
+	<key>RunAtLoad</key>
+	<string>YES</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Program</key>
+	<string>/xserve-frontpanel/hwmond</string>
+</dict>
+</plist>


### PR DESCRIPTION
This Pull Request adds a Plist that can be loaded into Launchd that will allow the hwmond process to load as root at boot. It will then keep the process alive while the system is up. This essentially makes it mimic the behavior of the way the previous hwmond file was handled by the OS.