### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,34 @@ cmake . && make
 ```bash
 ./hwmond
 ```
+
+---
+## Auto loading with Launchd
+The following optional instructions will walk you through using the included plist to auto load the hwmond file at boot and keep it running while the machine is running.
+
+Start by editing com.xserve-frontpanel.daemon.plist 
+
+```<string>/xserve-frontpanel/hwmond</string>
+```
+
+portion of the com.xserve-frontpanel.daemon.plist to have the location of where you have installed the file, IE. 
+
+```<string>/PATH-TO-HWMOND/hwmond</string>
+```
+
+One you have set the path to the hwmond. Open the terminal and cd to the containing directory. Once in the directory set the  permissions for the com.xserve-frontpanel.daemon.plist to 644 using the following command.
+
+```chmod 644 com.xserve-frontpanel.daemon.plist
+```
+
+Rather than physcially placing the plist into the LaunchDaemons directory it is better to create a symlink as follows, however if you prefer you can physically copy the file to the LaunchDaemons directory.
+
+```sudo ln -s com.xserve-frontpanel.daemon.plist /Library/LaunchDaemons/com.xserve-frontpanel.daemon.plist
+```
+
+You now need to load the plist into Launchd ( the process that loads and keeps stuff running )
+
+```sudo launchctl load -w /Library/LaunchDaemons/com.xserve-frontpanel.daemon.plist
+```
+
+The “-w” part of the last command tells the computer this process has to ALWAYS run. So even if you kill the HWmond process Launchd will start it back up. This ensure the front panel lights stay functional as long as the system is running.


### PR DESCRIPTION
This update to the ReadMe file adds information on how to load the Plist into Launchd to keep HWMOD running and for it to start at boot.