### PR TITLE
Fix implicit declaration of function strerror

### DIFF
--- a/cpu_usage.c
+++ b/cpu_usage.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <mach/mach_host.h>
 #include <mach/vm_map.h>
 #include <sys/types.h>


### PR DESCRIPTION
I'm working on getting this to compile on Linux. On Ubuntu Server 20.04 with gcc 9.3.0, I noticed this warning:

```
/home/rschmidt/xserve-frontpanel/cpu_usage.c:22:50: warning: implicit declaration of function ‘strerror’; did you mean ‘perror’? [-Wimplicit-function-declaration]
   22 |         printf("ERROR fetching hw.packages: %s", strerror(errno));
      |                                                  ^~~~~~~~
      |                                                  perror
```

strerror(3) tells us that it is defined in <string.h> so the fix is to include that header.

(I don't see this warning on macOS 10.13.6 with clang. Presumably there, <string.h> got included automatically by one of the other headers.)
